### PR TITLE
Enable strict mode only at function scope level

### DIFF
--- a/src/js/pg-ng-checkout.js
+++ b/src/js/pg-ng-checkout.js
@@ -1,6 +1,6 @@
-'use strict';
 (function(window){
-
+	'use strict';
+	
 	angular.module('pg-ng-checkout', [])
 	.provider('$pgCheckout', PgCheckout);
 


### PR DESCRIPTION
When bundled together with different files,
it'll apply strict mode for all of them which is
not always intended.